### PR TITLE
Hyperlink DOIs against preferred resolver

### DIFF
--- a/Biblatex.cfg
+++ b/Biblatex.cfg
@@ -11,7 +11,7 @@
 \DeclareFieldFormat{urldate}{[\bibstring{urlseen}\space#1]}
 \DeclareFieldFormat[article]{number}{\mkbibparens{#1}}
 \DeclareFieldFormat{doi}{%
-	\bibstring{urlfrom}\addcolon\space\mkbibacro{DOI}\addcolon\space \ifhyperref {\href{http://dx.doi.org/#1}{\nolinkurl{#1}}} {\nolinkurl{#1}}
+	\bibstring{urlfrom}\addcolon\space\mkbibacro{DOI}\addcolon\space \ifhyperref {\href{https://doi.org/#1}{\nolinkurl{#1}}} {\nolinkurl{#1}}
     }
 
 \renewbibmacro*{journal+issuetitle}{%

--- a/Imperial Harvard.cls
+++ b/Imperial Harvard.cls
@@ -45,7 +45,7 @@
 \DeclareFieldFormat{urldate}{[\bibstring{urlseen}\space#1]}
 \DeclareFieldFormat[article]{number}{\mkbibparens{#1}}
 \DeclareFieldFormat{doi}{%
-	\bibstring{urlfrom}\addcolon\space\mkbibacro{DOI}\addcolon\space \ifhyperref {\href{http://dx.doi.org/#1}{\nolinkurl{#1}}} {\nolinkurl{#1}}
+	\bibstring{urlfrom}\addcolon\space\mkbibacro{DOI}\addcolon\space \ifhyperref {\href{https://doi.org/#1}{\nolinkurl{#1}}} {\nolinkurl{#1}}
     }
 
 %%%%%%%%VOLUME ISSUE FORMAT ADJUSTMENTS%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/biblatex-imperial/imperialharvard.bbx
+++ b/biblatex-imperial/imperialharvard.bbx
@@ -32,7 +32,7 @@
 \DeclareFieldFormat{urldate}{[\bibstring{urlseen}\space#1]} %changes urldate to Accessed
 \DeclareFieldFormat[article]{number}{\mkbibparens{#1}} %Issue number in parentheses
 \DeclareFieldFormat{doi}{%
-	\bibstring{urlfrom}\addcolon\space\mkbibacro{DOI}\addcolon\space \ifhyperref {\href{http://dx.doi.org/#1}{\nolinkurl{#1}}} {\nolinkurl{#1}}
+	\bibstring{urlfrom}\addcolon\space\mkbibacro{DOI}\addcolon\space \ifhyperref {\href{https://doi.org/#1}{\nolinkurl{#1}}} {\nolinkurl{#1}}
     } %Formats URL display
 
 \renewbibmacro*{journal+issuetitle}{%

--- a/imperialharvard.bbx
+++ b/imperialharvard.bbx
@@ -32,7 +32,7 @@
 \DeclareFieldFormat{urldate}{[\bibstring{urlseen}\space#1]} %changes urldate to Accessed
 \DeclareFieldFormat[article]{number}{\mkbibparens{#1}} %Issue number in parentheses
 \DeclareFieldFormat{doi}{%
-	\bibstring{urlfrom}\addcolon\space\mkbibacro{DOI}\addcolon \ifhyperref {\href{http://dx.doi.org/#1}{\nolinkurl{#1}}} {\nolinkurl{#1}}
+	\bibstring{urlfrom}\addcolon\space\mkbibacro{DOI}\addcolon \ifhyperref {\href{https://doi.org/#1}{\nolinkurl{#1}}} {\nolinkurl{#1}}
     } %Formats URL display
 
 \renewbibmacro*{journal+issuetitle}{%


### PR DESCRIPTION
Hello :-)

The DOI foundation recommends [this new resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). Yes, a bit ironic that they would change the URL of their service, but it's now [encrypted](https://www.ssllabs.com/ssltest/analyze.html?d=doi.org). Because the old links with the `dx` subdomain continue to work, there is no urgent need to do anything.

However, I'd hereby like to suggest to follow the new recommendation and update all code that generates new DOI links.

Cheers!